### PR TITLE
Update to work with latest changes to basic Prom metrics

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/fnproject/ext-statsapi
 import:
 - package: github.com/fnproject/fn
-  version: improved_prom_metrics
+  version: master
   subpackages:
   - api/models
   - api/server

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/fnproject/ext-statsapi
 import:
 - package: github.com/fnproject/fn
-  version: master
+  version: improved_prom_metrics
   subpackages:
   - api/models
   - api/server

--- a/stats/build_prometheus_request.go
+++ b/stats/build_prometheus_request.go
@@ -6,22 +6,22 @@ import (
 
 // Prometheus metrics to use for global-scope queries, keyed by metric type
 var promMetricNamesForGlobalQueries = map[int]string{
-	completed: "fn_api_completed",
-	failed:    "fn_api_failed",
+	completed: "fn_completed",
+	failed:    "fn_failed",
 	durations: "fn_span_agent_submit_global_duration_seconds",
 }
 
 // Prometheus metrics to use for app-scoped queries, keyed by metric type
 var promMetricNamesForAppScopedQueries = map[int]string{
-	completed: "fn_api_completed",
-	failed:    "fn_api_failed",
+	completed: "fn_completed",
+	failed:    "fn_failed",
 	durations: "fn_span_agent_submit_app_duration_seconds",
 }
 
 // Prometheus metrics to use for route-scoped queries, keyed by metric type
 var promMetricNamesForRouteScopedQueries = map[int]string{
-	completed: "fn_api_completed",
-	failed:    "fn_api_failed",
+	completed: "fn_completed",
+	failed:    "fn_failed",
 	durations: "fn_span_agent_submit_duration_seconds",
 }
 
@@ -51,8 +51,8 @@ func buildPrometheusRequest(queryBuilder func(string, string, string, int, int, 
 func queryBuilderForCountersAndGauges(promHost string, promPort string, promMetricName string, queryScope int, metricType int, appName string, routeName string, startTimeString string, endTimeString string, stepString string) string {
 
 	var query string
-	appLabel := "app"
-	routeLabel := "path"
+	appLabel := "fn_appname"
+	routeLabel := "fn_path"
 	switch queryScope {
 	case query_scope_global:
 		query = "sum(" + promMetricName + ")"

--- a/stats/metrics_test.go
+++ b/stats/metrics_test.go
@@ -10,11 +10,19 @@ import (
 )
 
 // name of Prometheus metrics
-var callsMet = "fn_api_calls"
-var queuedMet = "fn_api_queued"
-var runningMet = "fn_api_running"
-var failedMet = "fn_api_failed"
-var completedMet = "fn_api_completed"
+const (
+	callsMet     = "fn_calls"
+	queuedMet    = "fn_queued"
+	runningMet   = "fn_running"
+	failedMet    = "fn_failed"
+	completedMet = "fn_completed"
+)
+
+// name of Prometheus labels
+const (
+	appnameLabel = "fn_appname"
+	pathLabel    = "fn_path"
+)
 
 // Test Prometheus metrics directly
 
@@ -314,11 +322,13 @@ func getMetrics(t *testing.T, appname string, routename string) map[string]int {
 	// get all Prometheus metrics
 	scrapedMetrics := getURLAsString(t, "http://localhost:8080/metrics")
 
-	requiredMetrics := []string{"fn_api_calls", "fn_api_queued", "fn_api_completed", "fn_api_failed", "fn_api_running"}
+	requiredMetrics := []string{callsMet, queuedMet, completedMet, failedMet, runningMet}
 	for _, thisMetricName := range requiredMetrics {
 		var thisMetricValue int
 		var err error
-		regularExpression := thisMetricName + `{app="` + appname + `",path="/` + routename + `"} (\d+)`
+		//regularExpression := thisMetricName + `{app="` + appname + `",path="/` + routename + `"} (\d+)`
+		regularExpression := thisMetricName + `{` + appnameLabel + `="` + appname + `",` + pathLabel + `="/` + routename + `"} (\d+)`
+
 		re := regexp.MustCompile(regularExpression)
 		matches := re.FindStringSubmatch(scrapedMetrics)
 		if len(matches) == 0 {

--- a/stats/utils_test.go
+++ b/stats/utils_test.go
@@ -36,33 +36,33 @@ func assertNotNil(t *testing.T, assertionText string, actual interface{}) {
 	}
 }
 
-// Return the sum of fn_api_completed for all applications and routes
+// Return the sum of fn_completed for all applications and routes
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getCompleted(t *testing.T) int {
 	completed := 0
 	for _, appname := range getApplications(t) {
 		for _, routename := range getRoutes(t, appname) {
 			metrics := getMetrics(t, appname, routename)
-			completed += metrics["fn_api_completed"]
+			completed += metrics[completedMet]
 		}
 	}
 	return completed
 }
 
-// Return the sum of fn_api_completed for all routes in the specified application
+// Return the sum of fn_completed for all routes in the specified application
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getCompletedForApp(t *testing.T, appname string) int {
 	completed := 0
 	for _, routename := range getRoutes(t, appname) {
-		completed += getMetrics(t, appname, routename)["fn_api_completed"]
+		completed += getMetrics(t, appname, routename)[completedMet]
 	}
 	return completed
 }
 
-// Return the value of fn_api_completed the specified application and route
+// Return the value of fn_completed the specified application and route
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getCompletedForAppAndRoute(t *testing.T, appname string, routename string) int {
-	return getMetrics(t, appname, routename)["fn_api_completed"]
+	return getMetrics(t, appname, routename)[completedMet]
 }
 
 // Return the names of all applications

--- a/test/run-all.bash
+++ b/test/run-all.bash
@@ -1,4 +1,7 @@
-bash test/run-cold-sync.bash
-bash test/run-hot-sync.bash
-bash test/run-cold-async.bash
-bash test/run-hot-async.bash
+WD=$PWD
+cd $GOPATH/src/github.com/fnproject/ext-statsapi/test
+bash run-cold-sync.bash
+bash run-hot-sync.bash
+bash run-cold-async.bash
+bash run-hot-async.bash
+cd $WD


### PR DESCRIPTION
Fn PR https://github.com/fnproject/fn/pull/671 changed the name and labels of the basic Prometheus metrics on which the stats API relies internally. 

This PR updates the stats API implementation to work with the new names. It also updates the tests to test some of the new basic Prometheus metrics directly.