### PR TITLE
Fix Prom query for histograms

### DIFF
--- a/examples/operators-clustered/tmp/main.go
+++ b/examples/operators-clustered/tmp/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"context"
+
+	"github.com/fnproject/fn/api/server"
+		_ "github.com/fnproject/ext-statsapi/stats"
+)
+
+func main() {
+	ctx := context.Background()
+	funcServer := server.NewFromEnv(ctx)
+		funcServer.AddExtensionByName("github.com/fnproject/ext-statsapi/stats")
+	funcServer.Start(ctx)
+}

--- a/stats/build_prometheus_request.go
+++ b/stats/build_prometheus_request.go
@@ -1,34 +1,8 @@
 package stats
 
-import (
-	"strconv"
-)
-
-// Prometheus metrics to use for global-scope queries, keyed by metric type
+// Prometheus metrics to use, keyed by metric type
 // see comment in statistics.go for information on adding a new metric
-var promMetricNamesForGlobalQueries = map[int]string{
-	completedConst: "fn_completed",
-	failedConst:    "fn_failed",
-	callsConst:     "fn_calls",
-	errorsConst:    "fn_errors",
-	timedoutConst:  "fn_timedout",
-	durationsConst: "fn_span_agent_submit_global_duration_seconds",
-}
-
-// Prometheus metrics to use for app-scoped queries, keyed by metric type
-// see comment in statistics.go for information on adding a new metric
-var promMetricNamesForAppScopedQueries = map[int]string{
-	completedConst: "fn_completed",
-	failedConst:    "fn_failed",
-	callsConst:     "fn_calls",
-	errorsConst:    "fn_errors",
-	timedoutConst:  "fn_timedout",
-	durationsConst: "fn_span_agent_submit_app_duration_seconds",
-}
-
-// Prometheus metrics to use for route-scoped queries, keyed by metric type
-// see comment in statistics.go for information on adding a new metric
-var promMetricNamesForRouteScopedQueries = map[int]string{
+var promMetricNames = map[int]string{
 	completedConst: "fn_completed",
 	failedConst:    "fn_failed",
 	callsConst:     "fn_calls",
@@ -39,73 +13,51 @@ var promMetricNamesForRouteScopedQueries = map[int]string{
 
 // Functions that know how to build the required Prometheus query, keyed by metric type
 // see comment in statistics.go for information on adding a new metric
-var queryBuilders = map[int]func(string, string, string, int, int, string, string, string, string, string) string{
+var queryBuilders = map[int]func(string, string, string, string, string, string, string, string) string{
 	completedConst: queryBuilderForCountersAndGauges,
 	failedConst:    queryBuilderForCountersAndGauges,
 	callsConst:     queryBuilderForCountersAndGauges,
 	errorsConst:    queryBuilderForCountersAndGauges,
 	timedoutConst:  queryBuilderForCountersAndGauges,
-	durationsConst: queryBuilderForForDurations,
+	durationsConst: queryBuilderForHistograms,
 }
 
-var promMetricNameMapsForQueries = make(map[int]map[int]string)
-
-func init() {
-	promMetricNameMapsForQueries[query_scope_global] = promMetricNamesForGlobalQueries
-	promMetricNameMapsForQueries[query_scope_app] = promMetricNamesForAppScopedQueries
-	promMetricNameMapsForQueries[query_scope_route] = promMetricNamesForRouteScopedQueries
-}
-
-func buildPrometheusRequest(queryBuilder func(string, string, string, int, int, string, string, string, string, string) string, promHost string, promPort string, queryScope int, metricType int, appName string, routeName string, startTimeString string, endTimeString string, stepString string) string {
-	promMetricName := promMetricNameMapsForQueries[queryScope][metricType]
+func buildPrometheusRequest(queryBuilder func(string, string, string, string, string, string, string, string) string, promHost string, promPort string, metricType int, appName string, routeName string, startTimeString string, endTimeString string, stepString string) string {
+	promMetricName := promMetricNames[metricType]
 	// use the specified queryBuilder function to construct a Prometheus query for the required metric
-	query := queryBuilder(promHost, promPort, promMetricName, queryScope, metricType, appName, routeName, startTimeString, endTimeString, stepString)
+	query := queryBuilder(promHost, promPort, promMetricName, appName, routeName, startTimeString, endTimeString, stepString)
 	// construct the complete request URL, including host, port, time range and step
 	return "http://" + promHost + ":" + promPort + "/api/v1/query_range?query=" + query + "&start=" + startTimeString + "&end=" + endTimeString + "&step=" + stepString
 }
 
-func queryBuilderForCountersAndGauges(promHost string, promPort string, promMetricName string, queryScope int, metricType int, appName string, routeName string, startTimeString string, endTimeString string, stepString string) string {
+func queryBuilderForCountersAndGauges(promHost string, promPort string, promMetricName string, appName string, routeName string, startTimeString string, endTimeString string, stepString string) string {
 
-	var query string
-	appLabel := "fn_appname"
-	routeLabel := "fn_path"
-	switch queryScope {
-	case query_scope_global:
-		query = "sum(" + promMetricName + ")"
-	case query_scope_app:
+	if appName == "" {
+		return "sum(" + promMetricName + ")"
+	} else if routeName == "" {
 		qualifiedPromMetricName := promMetricName + "{" + appLabel + "=\"" + appName + "\"}"
-		query = "sum(" + qualifiedPromMetricName + ")"
-	case query_scope_route:
+		return "sum(" + qualifiedPromMetricName + ")"
+	} else {
 		qualifiedPromMetricName := promMetricName + "{" + appLabel + "=\"" + appName + "\"," + routeLabel + "=\"" + routeName + "\"}"
-		query = "sum(" + qualifiedPromMetricName + ")"
-	default:
-		panic("Unexpected queryScope" + strconv.Itoa(queryScope))
+		return "sum(" + qualifiedPromMetricName + ")"
 	}
-	return query
+
 }
 
-func queryBuilderForForDurations(promHost string, promPort string, promMetricName string, queryScope int, metricType int, appName string, routeName string, startTimeString string, endTimeString string, stepString string) string {
+func queryBuilderForHistograms(promHost string, promPort string, promMetricName string, appName string, routeName string, startTimeString string, endTimeString string, stepString string) string {
 
-	var query string
-	appLabel := "fn_appname"
-	routeLabel := "fn_path"
 	rollingMeanPeriod := "1m"
-	switch queryScope {
-	case query_scope_global:
-		numerator := "rate(" + promMetricName + "_sum[" + rollingMeanPeriod + "])"
-		denominator := "rate(" + promMetricName + "_count[" + rollingMeanPeriod + "])"
-		query = numerator + "/" + denominator
-	case query_scope_app:
-		numerator := "rate(" + promMetricName + "_sum{" + appLabel + "=\"" + appName + "\"}[" + rollingMeanPeriod + "])"
-		denominator := "rate(" + promMetricName + "_count{" + appLabel + "=\"" + appName + "\"}[" + rollingMeanPeriod + "])"
-		query = numerator + "/" + denominator
-	case query_scope_route:
-		numerator := "rate(" + promMetricName + "_sum{" + appLabel + "=\"" + appName + "\"," + routeLabel + "=\"" + routeName + "\"}[" + rollingMeanPeriod + "])"
-		denominator := "rate(" +
-			promMetricName + "_count{" + appLabel + "=\"" + appName + "\"," + routeLabel + "=\"" + routeName + "\"}[" + rollingMeanPeriod + "])"
-		query = numerator + "/" + denominator
-	default:
-		panic("Unexpected queryScope" + strconv.Itoa(queryScope))
+	if appName == "" {
+		numerator := "sum(rate(" + promMetricName + "_sum[" + rollingMeanPeriod + "]))"
+		denominator := "sum(rate(" + promMetricName + "_count[" + rollingMeanPeriod + "]))"
+		return numerator + "/" + denominator
+	} else if routeName == "" {
+		numerator := "sum(rate(" + promMetricName + "_sum{" + appLabel + "=\"" + appName + "\"}[" + rollingMeanPeriod + "]))"
+		denominator := "sum(rate(" + promMetricName + "_count{" + appLabel + "=\"" + appName + "\"}[" + rollingMeanPeriod + "]))"
+		return numerator + "/" + denominator
+	} else {
+		numerator := "sum(rate(" + promMetricName + "_sum{" + appLabel + "=\"" + appName + "\"," + routeLabel + "=\"" + routeName + "\"}[" + rollingMeanPeriod + "]))"
+		denominator := "sum(rate(" + promMetricName + "_count{" + appLabel + "=\"" + appName + "\"," + routeLabel + "=\"" + routeName + "\"}[" + rollingMeanPeriod + "]))"
+		return numerator + "/" + denominator
 	}
-	return query
 }

--- a/stats/execute_prometheus_request.go
+++ b/stats/execute_prometheus_request.go
@@ -16,10 +16,6 @@ func executePrometheusRequest(url string) ([]metricsTimeValuePair, error) {
 		Timeout: time.Second * 2, // Maximum of 2 secs
 	}
 
-	//	fmt.Println("== URL sent to Prometheus= ===========================================")
-	//	fmt.Println(url)
-	//	fmt.Println("===End of URL sent to Prometheus =====================================")
-
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -37,10 +33,6 @@ func executePrometheusRequest(url string) ([]metricsTimeValuePair, error) {
 		return nil, readErr
 	}
 
-	//	fmt.Println("== JSON returned from Prometheus= ====================================")
-	//	fmt.Println(string(body[:]))
-	//	fmt.Println("===End of JSON returned from Prometheus ==============================")
-
 	// Assume result is of type "matrix" (meaning this is a range vector)
 
 	thisPromQueryRangeData := promQueryRangeData{}
@@ -54,12 +46,12 @@ func executePrometheusRequest(url string) ([]metricsTimeValuePair, error) {
 	}
 
 	if len(thisPromQueryRangeData.Data.Result) > 1 {
-		//  we must have got the query wrong
-		// this is a very verbose error message, but it should never happen, so we need all the info we can get
+		// Range query has returned multiple ranges! This should never happen: we must have got the query wrong
+		// Return a suitably verbose error message to allow investigation
 		return nil, errors.New("data array returned by Prometheus has more than one element: url=" + url + ", returned JSON=" + string(body[:]))
 	}
 
-	// how many data time-value pairs have we been given
+	// how many data time-value pairs have we been given?
 	var numberOfTimeValuePairs int
 	if len(thisPromQueryRangeData.Data.Result) == 0 {
 		numberOfTimeValuePairs = 0

--- a/stats/statistics_test.go
+++ b/stats/statistics_test.go
@@ -12,10 +12,6 @@ import (
 // - a Prometheus server, configured to scrape data from the Fn server
 // Also requires the following to be run beforehand
 //   bash test/create.bash
-//   bash test/run-cold-sync.bash
-//   bash test/run-cold-async.bash
-//   bash test/run-hot-sync.bash
-//   bash test/run-hot-async.bash
 
 func TestMain(m *testing.M) {
 	setup()
@@ -75,11 +71,6 @@ func TestNeverCalled(t *testing.T) {
 
 func TestAllFuncs(t *testing.T) {
 	// verify stats for all functions
-	// Assumes all the following have been run
-	// test/run-cold-sync.bash
-	// test/run-cold-async.bash
-	// test/run-hot-sync.bash
-	// test/run-hot-async.bash
 	appname := ""
 	routename := ""
 	verifyWithRetries(t, appname, routename)
@@ -87,15 +78,12 @@ func TestAllFuncs(t *testing.T) {
 
 func TestAllFuncsPerApp(t *testing.T) {
 	// verify stats across all three functions in the app hello-cold-async-a
-	// Assumes all the following have been run
-	// test/run-cold-async.bash
 	appname := "hello-cold-async-a"
 	routename := ""
 	verifyWithRetries(t, appname, routename)
 }
 
 // Test sync cold
-// Assumes test/run-cold-sync.bash has been run
 func TestSyncCold(t *testing.T) {
 	// verify stats for sync cold functions
 	appname := "hello-cold-sync-a"
@@ -104,7 +92,6 @@ func TestSyncCold(t *testing.T) {
 }
 
 // Test async cold
-// Assumes test/run-cold-async.bash has been run
 func TestAsyncCold(t *testing.T) {
 	// verify stats for async cold functions
 	appname := "hello-cold-async-a"
@@ -113,7 +100,6 @@ func TestAsyncCold(t *testing.T) {
 }
 
 // Test sync hot
-// Assumes test/run-hot-sync.bash has been run
 func TestSyncHot(t *testing.T) {
 	// verify stats for sync hot functions
 	appname := "hello-hot-sync-a"


### PR DESCRIPTION
I discovered that the Prometheus query that was currently used to obtain "durations" did not work when Prometheus was scraping data from a cluster of multiple Fn servers. This is because the label `instance` now has multiple values which causes the query to return multiple ranges rather than the single range that is expected and needed.

I therefore changed the query to combine the ranges (by doing a "sum" of both the numerator and the denominator) , so that only a single range is ever returned.

This allows me to simplify some of the existing logic.