### PR TITLE
Changed timeout to timeouts

### DIFF
--- a/stats/build_prometheus_request.go
+++ b/stats/build_prometheus_request.go
@@ -7,7 +7,9 @@ var promMetricNames = map[int]string{
 	failedConst:    "fn_failed",
 	callsConst:     "fn_calls",
 	errorsConst:    "fn_errors",
-	timedoutConst:  "fn_timedout",
+	timedoutConst:  "fn_timeouts",
+	runningConst:   "fn_running", // used for tests only
+	queuedConst:    "fn_queued",  // used for tests only
 	durationsConst: "fn_span_agent_submit_duration_seconds",
 }
 

--- a/stats/metrics_test.go
+++ b/stats/metrics_test.go
@@ -8,17 +8,6 @@ import (
 	"time"
 )
 
-// name of Prometheus metrics
-const (
-	callsMet     = "fn_calls"
-	queuedMet    = "fn_queued"
-	runningMet   = "fn_running"
-	failedMet    = "fn_failed"
-	completedMet = "fn_completed"
-	timedoutMet  = "fn_timedout"
-	errorsMet    = "fn_errors"
-)
-
 // name of Prometheus labels
 const (
 	appnameLabel = "fn_appname"
@@ -160,13 +149,13 @@ func doTestSuccessful(t *testing.T, appname string, routename string, sync bool)
 	metrics1 := getAllMetricsForAppAndRoute(t, appname, routename)
 
 	message := "after calling " + appname + "/" + routename + " with sleeptime " + strconv.Itoa(sleeptime)
-	assertIntsEqual(t, message+" calls should have increased by 1", metrics0[callsMet]+1, metrics1[callsMet])
-	assertIntsEqual(t, message+" completed should have increased by 1", metrics0[completedMet]+1, metrics1[completedMet])
-	assertIntsEqual(t, message+" queued should be unchanged", metrics0[queuedMet], metrics1[queuedMet])
-	assertIntsEqual(t, message+" failed should be unchanged", metrics0[failedMet], metrics1[failedMet])
-	assertIntsEqual(t, message+" running should be unchanged", metrics0[runningMet], metrics1[runningMet])
-	assertIntsEqual(t, message+" timedout should be unchanged", metrics0[timedoutMet], metrics1[timedoutMet])
-	assertIntsEqual(t, message+" errors should be unchanged", metrics0[errorsMet], metrics1[errorsMet])
+	assertIntsEqual(t, message+" calls should have increased by 1", metrics0[promMetricNames[callsConst]]+1, metrics1[promMetricNames[callsConst]])
+	assertIntsEqual(t, message+" completed should have increased by 1", metrics0[promMetricNames[completedConst]]+1, metrics1[promMetricNames[completedConst]])
+	assertIntsEqual(t, message+" queued should be unchanged", metrics0[promMetricNames[queuedConst]], metrics1[promMetricNames[queuedConst]])
+	assertIntsEqual(t, message+" failed should be unchanged", metrics0[promMetricNames[failedConst]], metrics1[promMetricNames[failedConst]])
+	assertIntsEqual(t, message+" running should be unchanged", metrics0[promMetricNames[runningConst]], metrics1[promMetricNames[runningConst]])
+	assertIntsEqual(t, message+" timedout should be unchanged", metrics0[promMetricNames[timedoutConst]], metrics1[promMetricNames[timedoutConst]])
+	assertIntsEqual(t, message+" errors should be unchanged", metrics0[promMetricNames[errorsConst]], metrics1[promMetricNames[errorsConst]])
 }
 
 func doTestWithTimeout(t *testing.T, appname string, routename string, sync bool, hot bool) {
@@ -207,13 +196,13 @@ func doTestWithTimeout(t *testing.T, appname string, routename string, sync bool
 	metrics1 := getAllMetricsForAppAndRoute(t, appname, routename)
 
 	message := "after calling " + appname + "/" + routename + " with sleeptime " + strconv.Itoa(sleeptime)
-	assertIntsEqual(t, message+" calls should have increased by 1", metrics0[callsMet]+1, metrics1[callsMet])
-	assertIntsEqual(t, message+" completed should be unchanged", metrics0[completedMet], metrics1[completedMet])
-	assertIntsEqual(t, message+" queued should be unchanged", metrics0[queuedMet], metrics1[queuedMet])
-	assertIntsEqual(t, message+" failed should have increased by 1", metrics0[failedMet]+1, metrics1[failedMet])
-	assertIntsEqual(t, message+" running should be unchanged", metrics0[runningMet], metrics1[runningMet])
-	assertIntsEqual(t, message+" timedout should have increased by 1", metrics0[timedoutMet]+1, metrics1[timedoutMet])
-	assertIntsEqual(t, message+" errors should be unchanged", metrics0[errorsMet], metrics1[errorsMet])
+	assertIntsEqual(t, message+" calls should have increased by 1", metrics0[promMetricNames[callsConst]]+1, metrics1[promMetricNames[callsConst]])
+	assertIntsEqual(t, message+" completed should be unchanged", metrics0[promMetricNames[completedConst]], metrics1[promMetricNames[completedConst]])
+	assertIntsEqual(t, message+" queued should be unchanged", metrics0[promMetricNames[queuedConst]], metrics1[promMetricNames[queuedConst]])
+	assertIntsEqual(t, message+" failed should have increased by 1", metrics0[promMetricNames[failedConst]]+1, metrics1[promMetricNames[failedConst]])
+	assertIntsEqual(t, message+" running should be unchanged", metrics0[promMetricNames[runningConst]], metrics1[promMetricNames[runningConst]])
+	assertIntsEqual(t, message+" timedout should have increased by 1", metrics0[promMetricNames[timedoutConst]]+1, metrics1[promMetricNames[timedoutConst]])
+	assertIntsEqual(t, message+" errors should be unchanged", metrics0[promMetricNames[errorsConst]], metrics1[promMetricNames[errorsConst]])
 }
 
 func doTestWithPanic(t *testing.T, appname string, routename string, sync bool) {
@@ -250,13 +239,13 @@ func doTestWithPanic(t *testing.T, appname string, routename string, sync bool) 
 	metrics1 := getAllMetricsForAppAndRoute(t, appname, routename)
 
 	message := "after calling " + appname + "/" + routename + " with sleeptime " + strconv.Itoa(sleeptime)
-	assertIntsEqual(t, message+" calls should have increased by 1", metrics0[callsMet]+1, metrics1[callsMet])
-	assertIntsEqual(t, message+" completed should be unchanged", metrics0[completedMet], metrics1[completedMet])
-	assertIntsEqual(t, message+" queued should be unchanged", metrics0[queuedMet], metrics1[queuedMet])
-	assertIntsEqual(t, message+" failed should have increased by 1", metrics0[failedMet]+1, metrics1[failedMet])
-	assertIntsEqual(t, message+" running should be unchanged", metrics0[runningMet], metrics1[runningMet])
-	assertIntsEqual(t, message+" timedout should be unchanged", metrics0[timedoutMet], metrics1[timedoutMet])
-	assertIntsEqual(t, message+" errors should have increased by 1", metrics0[errorsMet]+1, metrics1[errorsMet])
+	assertIntsEqual(t, message+" calls should have increased by 1", metrics0[promMetricNames[callsConst]]+1, metrics1[promMetricNames[callsConst]])
+	assertIntsEqual(t, message+" completed should be unchanged", metrics0[promMetricNames[completedConst]], metrics1[promMetricNames[completedConst]])
+	assertIntsEqual(t, message+" queued should be unchanged", metrics0[promMetricNames[queuedConst]], metrics1[promMetricNames[queuedConst]])
+	assertIntsEqual(t, message+" failed should have increased by 1", metrics0[promMetricNames[failedConst]]+1, metrics1[promMetricNames[failedConst]])
+	assertIntsEqual(t, message+" running should be unchanged", metrics0[promMetricNames[runningConst]], metrics1[promMetricNames[runningConst]])
+	assertIntsEqual(t, message+" timedout should be unchanged", metrics0[promMetricNames[timedoutConst]], metrics1[promMetricNames[timedoutConst]])
+	assertIntsEqual(t, message+" errors should have increased by 1", metrics0[promMetricNames[errorsConst]]+1, metrics1[promMetricNames[errorsConst]])
 }
 
 func call(t *testing.T, appname string, routename string, sync bool, forceTimeout bool, forcePanic bool) string {

--- a/stats/statistics.go
+++ b/stats/statistics.go
@@ -70,6 +70,8 @@ const (
 	callsConst     = iota
 	errorsConst    = iota
 	timedoutConst  = iota
+	queuedConst    = iota // used only in tests
+	runningConst   = iota // used only in tests
 )
 
 // in this map, the key is the constant for the type of statistic and
@@ -81,7 +83,7 @@ var jsonKeys = map[int]string{
 	durationsConst: "durations",
 	callsConst:     "calls",
 	errorsConst:    "errors",
-	timedoutConst:  "timedout",
+	timedoutConst:  "timeouts",
 }
 
 var appLabel = "fn_appname"

--- a/stats/statistics_test.go
+++ b/stats/statistics_test.go
@@ -210,23 +210,23 @@ func verifyOnce(t *testing.T, response interface{}, expectedMetrics map[string]i
 	}
 
 	// check the fields in the data array that correspond to basic metrics
-	err = checkMetricField(t, dataAsMap, "calls", expectedMetrics["fn_calls"])
+	err = checkMetricField(t, dataAsMap, jsonKeys[callsConst], expectedMetrics[promMetricNames[callsConst]])
 	if err != nil {
 		return err
 	}
-	err = checkMetricField(t, dataAsMap, "completed", expectedMetrics["fn_completed"])
+	err = checkMetricField(t, dataAsMap, jsonKeys[completedConst], expectedMetrics[promMetricNames[completedConst]])
 	if err != nil {
 		return err
 	}
-	err = checkMetricField(t, dataAsMap, "failed", expectedMetrics["fn_failed"])
+	err = checkMetricField(t, dataAsMap, jsonKeys[failedConst], expectedMetrics[promMetricNames[failedConst]])
 	if err != nil {
 		return err
 	}
-	err = checkMetricField(t, dataAsMap, "timedout", expectedMetrics["fn_timedout"])
+	err = checkMetricField(t, dataAsMap, jsonKeys[timedoutConst], expectedMetrics[promMetricNames[timedoutConst]])
 	if err != nil {
 		return err
 	}
-	err = checkMetricField(t, dataAsMap, "errors", expectedMetrics["fn_errors"])
+	err = checkMetricField(t, dataAsMap, jsonKeys[errorsConst], expectedMetrics[promMetricNames[errorsConst]])
 	if err != nil {
 		return err
 	}

--- a/stats/utils_test.go
+++ b/stats/utils_test.go
@@ -11,7 +11,8 @@ import (
 	"time"
 )
 
-var requiredMetrics = []string{callsMet, queuedMet, completedMet, failedMet, runningMet, timedoutMet, errorsMet}
+var requiredMetrics = []string{promMetricNames[callsConst], promMetricNames[queuedConst],
+	promMetricNames[completedConst], promMetricNames[failedConst], promMetricNames[runningConst], promMetricNames[timedoutConst], promMetricNames[errorsConst]}
 
 // This file contains test utilities only (no tests)
 
@@ -70,91 +71,91 @@ func checkNotNil(t *testing.T, assertionText string, actual interface{}) error {
 // Return the sum of fn_completed for all applications and routes
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getCompletedForAll(t *testing.T) int {
-	return getMetricForAll(t, completedMet)
+	return getMetricForAll(t, promMetricNames[completedConst])
 }
 
 // Return the sum of fn_completed for all routes in the specified application
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getCompletedForApp(t *testing.T, appname string) int {
-	return getMetricForApp(t, appname, completedMet)
+	return getMetricForApp(t, appname, promMetricNames[completedConst])
 }
 
 // Return the value of fn_completed for the specified application and route
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getCompletedForAppAndRoute(t *testing.T, appname string, routename string) int {
-	return getMetricForAppAndRoute(t, appname, routename, completedMet)
+	return getMetricForAppAndRoute(t, appname, routename, promMetricNames[completedConst])
 }
 
 // Return the sum of fn_failed for all applications and routes
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getFailedForAll(t *testing.T) int {
-	return getMetricForAll(t, failedMet)
+	return getMetricForAll(t, promMetricNames[failedConst])
 }
 
 // Return the sum of fn_failed for all routes in the specified application
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getFailedForApp(t *testing.T, appname string) int {
-	return getMetricForApp(t, appname, failedMet)
+	return getMetricForApp(t, appname, promMetricNames[failedConst])
 }
 
 // Return the value of fn_failed for the specified application and route
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getFailedForAppAndRoute(t *testing.T, appname string, routename string) int {
-	return getMetricForAppAndRoute(t, appname, routename, failedMet)
+	return getMetricForAppAndRoute(t, appname, routename, promMetricNames[failedConst])
 }
 
 // Return the sum of fn_calls for all applications and routes
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getCallsForAll(t *testing.T) int {
-	return getMetricForAll(t, callsMet)
+	return getMetricForAll(t, promMetricNames[callsConst])
 }
 
 // Return the sum of fn_calls for all routes in the specified application
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getCallsForApp(t *testing.T, appname string) int {
-	return getMetricForApp(t, appname, callsMet)
+	return getMetricForApp(t, appname, promMetricNames[callsConst])
 }
 
 // Return the value of fn_calls for the specified application and route
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getCallsForAppAndRoute(t *testing.T, appname string, routename string) int {
-	return getMetricForAppAndRoute(t, appname, routename, callsMet)
+	return getMetricForAppAndRoute(t, appname, routename, promMetricNames[callsConst])
 }
 
 // Return the sum of fn_errors for all applications and routes
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getErrorsForAll(t *testing.T) int {
-	return getMetricForAll(t, errorsMet)
+	return getMetricForAll(t, promMetricNames[errorsConst])
 }
 
 // Return the sum of fn_errors for all routes in the specified application
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getErrorsForApp(t *testing.T, appname string) int {
-	return getMetricForApp(t, appname, errorsMet)
+	return getMetricForApp(t, appname, promMetricNames[errorsConst])
 }
 
 // Return the value of fn_errors for the specified application and route
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getErrorsForAppAndRoute(t *testing.T, appname string, routename string) int {
-	return getMetricForAppAndRoute(t, appname, routename, errorsMet)
+	return getMetricForAppAndRoute(t, appname, routename, promMetricNames[errorsConst])
 }
 
 // Return the sum of fn_timedout for all applications and routes
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getTimedOutForAll(t *testing.T) int {
-	return getMetricForAll(t, timedoutMet)
+	return getMetricForAll(t, promMetricNames[timedoutConst])
 }
 
 // Return the sum of fn_timedout for all routes in the specified application
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getImedOutForApp(t *testing.T, appname string) int {
-	return getMetricForApp(t, appname, timedoutMet)
+	return getMetricForApp(t, appname, promMetricNames[timedoutConst])
 }
 
 // Return the value of fn_timedout for the specified application and route
 // Metric values are obtained by scraping the /metrics endpoint directly
 func getTimedOutForAppAndRoute(t *testing.T, appname string, routename string) int {
-	return getMetricForAppAndRoute(t, appname, routename, timedoutMet)
+	return getMetricForAppAndRoute(t, appname, routename, promMetricNames[timedoutConst])
 }
 
 // Return the sum of the specified Prometheus gauge or counter metric for all applications and routes


### PR DESCRIPTION
This PR updates the stats API following the renaming of the Prometheus metric `fn_timedout` to `fn_timedouts`, as proposed in Fn PR https://github.com/fnproject/fn/pull/709.

It also changes the name of the key in the returned JSON structure from `timedout` to `timeouts`.

The CI tests for this PR will fail until that PR is merged.